### PR TITLE
Fix job control callbacks

### DIFF
--- a/autoload/features/debugger.vim
+++ b/autoload/features/debugger.vim
@@ -10,7 +10,7 @@ let s:NimDebugger = {
             \ 'pty': 1,
             \ }
 
-function! s:NimDebugger.on_stdout(job, chunk, ...)
+function! s:NimDebugger.on_stdout(job, chunk, type)
     for line in a:chunk
         " *** endb| reached edb.nim(4) wat ***
         " let matched = matchlist(line, "\\*\\*\\* endb\|\(.*\)$")
@@ -18,11 +18,11 @@ function! s:NimDebugger.on_stdout(job, chunk, ...)
     endfor
 endfunction
 
-function! s:NimDebugger.on_stderr(job, chunk, ...)
+function! s:NimDebugger.on_stderr(job, chunk, type)
     " echoerr "Error" . join(a:chunk, "\n")
 endfunction
 
-function! s:NimDebugger.on_exit(...)
+function! s:NimDebugger.on_exit(job, chunk, type)
     echoerr "Done"
     let s:edb_terminal_job = -2
 endfunction

--- a/autoload/highlighter.vim
+++ b/autoload/highlighter.vim
@@ -41,13 +41,13 @@ let s:NimHighlighter = {
             \ }
             " \ 'pty': 1
 
-function! s:NimHighlighter.on_stdout(job, chunk, ...)
+function! s:NimHighlighter.on_stdout(job, chunk, type)
     if len(a:chunk[0]) != 0 && !(a:chunk[0] =~ "^usage")
         call extend(self.lines, a:chunk)
     endif
 endfunction
 
-function! s:NimHighlighter.on_stderr(job, chunk, ...)
+function! s:NimHighlighter.on_stderr(job, chunk, type)
 endfunction
 
 function! Remove(id)
@@ -57,7 +57,7 @@ function! Remove(id)
     endtry
 endfunction
 
-function! s:NimHighlighter.on_exit(...)
+function! s:NimHighlighter.on_exit(job, chunk, type)
     if empty(self.lines) && self.file != expand("%:p")
         return
     endif

--- a/autoload/suggest.vim
+++ b/autoload/suggest.vim
@@ -12,15 +12,15 @@ let s:NimSuggest = {
             \ 'pty': 0,
             \ }
 
-function! s:NimSuggest.on_stdout(job, chunk)
+function! s:NimSuggest.on_stdout(job, chunk, type)
     call extend(self.lines, a:chunk)
 endfunction
 
-function! s:NimSuggest.on_stderr(job, chunk)
+function! s:NimSuggest.on_stderr(job, chunk, type)
 endfunction
 
 
-function! s:NimSuggest.on_exit()
+function! s:NimSuggest.on_exit(job, chunk, type)
     echo ""
     let self.lines = util#FilterCompletions(self.lines)
     if len(self.lines) > 0


### PR DESCRIPTION
Added missing event type parameter, as per [the neovim docs](https://neovim.io/doc/user/job_control.html#on_stdout). Fixes https://github.com/baabelfish/nvim-nim/issues/49. Also changed varargs parameters to explicit to avoid future confusion.