### PR TITLE
Fix hlsearch highlighting while using nimsuggest or semantic highlighter

### DIFF
--- a/autoload/highlighter.vim
+++ b/autoload/highlighter.vim
@@ -96,9 +96,9 @@ function! s:NimHighlighter.on_exit(...)
 
         if has_key(s:highlights, ctype)
             if has_key(semantics_set, ctype)
-                call add(b:highlights, matchaddpos("Semantic" . abs(util#djb(strpart(str, c - 1, s))) % 20, [[line, c, s]]))
+                call add(b:highlights, matchaddpos("Semantic" . abs(util#djb(strpart(str, c - 1, s))) % 20, [[line, c, s]], -1))
             else
-                call add(b:highlights, matchaddpos(s:highlights[ctype], [[line, c, s]]))
+                call add(b:highlights, matchaddpos(s:highlights[ctype], [[line, c, s]], -1))
             endif
         endif
     endfor


### PR DESCRIPTION
`matchaddpos` can take a [priority parameter][0].
By default, the priority is 10 and overrides the highlight priority
of hlsearch (which is 0).
By specifying a priority of -1, hlsearch isn't overridden by
the highlighter, and searches are highlighted as expected by the user.

[0]: https://neovim.io/doc/user/eval.html#matchadd()